### PR TITLE
fix: 🐛 add navigate(0) to refresh after CU action

### DIFF
--- a/app/javascript/components/activities/ActivityForm.tsx
+++ b/app/javascript/components/activities/ActivityForm.tsx
@@ -53,6 +53,7 @@ export default function ActivityForm({ trip }: ActivityFormProps) {
 
       window.alert("Activity added!");
       navigate(`/trips/${trip.id}`);
+      navigate(0);
     } catch (error) {
       console.error(error);
     }

--- a/app/javascript/components/stops/StopForm.tsx
+++ b/app/javascript/components/stops/StopForm.tsx
@@ -35,6 +35,7 @@ export default function StopForm({ trip, stays }: StopFormProps) {
 
       window.alert("Stop added!");
       navigate(`/trips/${trip.id}`);
+      navigate(0);
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
- [x] Add `navigate(0)` to refresh after create or update action and show updated data